### PR TITLE
Adds a demonstration of BrowserWindow.SetProgressBar.

### DIFF
--- a/ElectronNET-API-Demos/Controllers/ProgressBarController.cs
+++ b/ElectronNET-API-Demos/Controllers/ProgressBarController.cs
@@ -1,0 +1,29 @@
+﻿using ElectronNET.API;
+using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+
+namespace ElectronNET_API_Demos.Controllers
+{
+    public class ProgressBarController : Controller
+    {
+        public IActionResult Index()
+        {
+            if (HybridSupport.IsElectronActive)
+            {
+                Electron.IpcMain.On("set-progress-bar", async (args) =>
+                {
+                    var mainWindow = Electron.WindowManager.BrowserWindows.First();
+                    mainWindow.SetProgressBar(0.5);
+                });
+
+                Electron.IpcMain.On("clear-progress-bar", async (args) =>
+                {
+                    var mainWindow = Electron.WindowManager.BrowserWindows.First();
+                    mainWindow.SetProgressBar(-1);
+                });
+            }
+
+            return View();
+        }
+    }
+}

--- a/ElectronNET-API-Demos/Views/Home/Index.cshtml
+++ b/ElectronNET-API-Demos/Views/Home/Index.cshtml
@@ -25,6 +25,7 @@
     <link rel="import" href="appsysinformation">
     <link rel="import" href="clipboard">
     <link rel="import" href="pdf">
+    <link rel="import" href="progressbar">
     <link rel="import" href="desktopcapturer">
 </head>
 <body>
@@ -61,6 +62,7 @@
             <button type="button" id="button-notifications" data-section="notifications" class="nav-button"> Notifications with and without custom <em>image</em></button>
             <button type="button" id="button-dialogs" data-section="dialogs" class="nav-button">Use system <em>dialogs</em></button>
             <button type="button" id="button-tray" data-section="tray" class="nav-button">Put your app in the <em>tray</em></button>
+            <button type="button" id="button-progress-bar" data-section="progress-bar" class="nav-button">Show <em>progress</em></button>
         </div>
 
         <div class="nav-item u-category-communication">

--- a/ElectronNET-API-Demos/Views/ProgressBar/Index.cshtml
+++ b/ElectronNET-API-Demos/Views/ProgressBar/Index.cshtml
@@ -1,0 +1,69 @@
+﻿<template class="task-template">
+    <section id="progress-bar-section" class="section js-section u-category-native-ui">
+        <header class="section-header">
+            <div class="section-wrapper">
+                <h1>
+                    Set Progress Bar
+                </h1>
+                <h3>The <code>BrowserWindow.SetProgressBar</code> method in Electron.NET allows you set a progress bar that appers in the task bar.</h3>
+
+                <p>This module works in the main process.</p>
+
+                <p>You find the sample source code in <code>Controllers\ProgressBarController.cs</code>.</p>
+            </div>
+        </header>
+
+        <div class="demo">
+            <div class="demo-wrapper">
+                <button id="set-progress-bar-toggle" class="js-container-target demo-toggle-button">
+                    Set the Progress Bar in Taskbar
+                    <div class="demo-meta u-avoid-clicks">Supports: Win, macOS, Linux (Unity only)<span class="demo-meta-divider">|</span> Process: Main</div>
+                </button>
+                <div class="demo-box">
+                    <div class="demo-controls">
+                        <button class="demo-button" id="set-progress-bar">View Demo</button>
+                    </div>
+                    <p>This demonstrates using the <code>BrowserWindow.SetProgressBar</code> to set the window's progress.</p>
+                    <p>Clicking the demo button will set the progress to 50%.</p>
+                    <h5>Main Process (C#)</h5>
+                    <pre><code class="csharp">var mainWindow = Electron.WindowManager.BrowserWindows.First();
+mainWindow.SetProgressBar(0.5);</code></pre>
+                </div>
+            </div>
+        </div>
+
+        <div class="demo">
+            <div class="demo-wrapper">
+                <button id="clear-progress-bar-toggle" class="js-container-target demo-toggle-button">
+                    Clear the Progress Bar from Taskbar
+                    <div class="demo-meta u-avoid-clicks">Supports: Win, macOS, Linux (Unity only)<span class="demo-meta-divider">|</span> Process: Main</div>
+                </button>
+                <div class="demo-box">
+                    <div class="demo-controls">
+                        <button class="demo-button" id="clear-progress-bar">View Demo</button>
+                    </div>
+                    <p>This demonstrates using the <code>BrowserWindow.SetProgressBar</code> to clear the window's progress.</p>
+                        <h5>Main Process (C#)</h5>
+                        <pre><code class="csharp">var mainWindow = Electron.WindowManager.BrowserWindows.First();
+mainWindow.SetProgressBar(-1);</code></pre>
+                </div>
+            </div>
+        </div>
+
+        <script>
+            (function () {
+                const { ipcRenderer } = require("electron");
+
+                document.getElementById("set-progress-bar").addEventListener("click", () => {
+                    ipcRenderer.send("set-progress-bar");
+                });
+
+                document.getElementById("clear-progress-bar").addEventListener("click", () => {
+                    ipcRenderer.send("clear-progress-bar");
+                });
+            }());
+        </script>
+
+
+    </section>
+</template>

--- a/ElectronNET-API-Demos/Views/Shell/Index.cshtml
+++ b/ElectronNET-API-Demos/Views/Shell/Index.cshtml
@@ -47,8 +47,8 @@ await Electron.Shell.ShowItemInFolderAsync(path);</code></pre>
                     <p>When the demo button is clicked, the electron website will open in your browser.<p>
                         <h5>Main Process (C#)</h5>
                         <pre><code class="csharp">await Electron.Shell.OpenExternalAsync("https://github.com/ElectronNET");</code></pre>
+                </div>
             </div>
-        </div>
         </div>
         
         <script>


### PR DESCRIPTION
Accompanying demo/test for https://github.com/ElectronNET/Electron.NET/pull/240. You need the API/CLI updated to include that branch before this will compile.

Also, when I was tested, I had https://github.com/ElectronNET/electron.net-api-demos/pull/13 applied. That is not included in the PR for simplicity when merging.

I tested the `ProgressBarOptions` setting, but decided it wasn't worth a demo.