### PR TITLE
Fix for Electron 11

### DIFF
--- a/ElectronNET-API-Demos/wwwroot/assets/imports.js
+++ b/ElectronNET-API-Demos/wwwroot/assets/imports.js
@@ -1,12 +1,39 @@
-const links = document.querySelectorAll('link[rel="import"]')
+// copy from https://github.com/electron/electron-api-demos/pull/466/
 
-// Import and add each page to the DOM
-Array.prototype.forEach.call(links, function (link) {
-  let template = link.import.querySelector('.task-template')
-  let clone = document.importNode(template.content, true)
-  if (link.href.match('about.html')) {
-    document.querySelector('body').appendChild(clone)
-  } else {
-    document.querySelector('.content').appendChild(clone)
-  }
-})
+function includeHTML() {
+    var links, i, elmnt, href, request;
+    /* Loop through a collection of all HTML elements: */
+    links = document.querySelectorAll('link[rel="import"]');
+    // console.log(links)
+    for (i = 0; i < links.length; i++) {
+        elmnt = links[i];
+        /*search for elements with a certain atrribute:*/
+        href = elmnt.getAttribute('href');
+        // console.log(href)
+        if (href) {
+            /* Make an HTTP request using the attribute value as the file name: */
+            request = new XMLHttpRequest();
+            request.onreadystatechange = function () {
+                if (this.readyState == 4) {
+                    if (this.status == 200) { elmnt.innerHTML = this.responseText; }
+                    if (this.status == 404) { elmnt.innerHTML = "Page not found."; }
+                    // console.log(elmnt)                // <link ref="import" href="sections/windows/crash-hang.html">
+                    let template = elmnt.querySelector('.task-template')
+                    let clone = document.importNode(template.content, true)
+                    if (href.match('about')) {
+                        document.querySelector('body').appendChild(clone)
+                    } else {
+                        document.querySelector('.content').appendChild(clone)
+                    }
+                    elmnt.remove();
+                    includeHTML();
+                }
+            }
+            request.open("GET", href, false); // `false` makes the request synchronous
+            request.send();
+            /* Exit the function: */
+            return;
+        }
+    }
+}
+includeHTML();

--- a/ElectronNET-API-Demos/wwwroot/assets/nav.js
+++ b/ElectronNET-API-Demos/wwwroot/assets/nav.js
@@ -15,8 +15,11 @@ function handleSectionTrigger(event) {
     event.target.classList.add('is-selected');
 
     // Display the current section
-    const sectionId = event.target.dataset.section + '-section'
-    document.getElementById(sectionId).classList.add('is-shown');
+    const sectionId = event.target.dataset.section + '-section';
+    const section = document.getElementById(sectionId);
+    if (!!section) {
+        section.classList.add('is-shown');
+    }
 }
 
 function activateDefaultSection () {
@@ -61,7 +64,10 @@ function hideAllSectionsAndDeselectButtons () {
 
 function displayAbout() {
     hideNav();
-  document.querySelector('#about-modal').classList.add('is-shown')
+    const modal = document.querySelector('#about-modal');
+    if (!!modal) {
+        modal.classList.add('is-shown');
+    }
 }
 
 function hideNav() {


### PR DESCRIPTION
Chrome V80 doesn't support `<link rel="import">` anymore.

This PR applies the patch suggested to the base Electron API demo (which still suffers the same problem): https://github.com/electron/electron-api-demos/pull/466/

Fixes #22 
Fixes #21 